### PR TITLE
Add installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This repo contains the agent skills for JOYCO.
 
+## Install
+
+```sh
+pnpx skills add joyco-studio/skills
+```
+
 ## Skills
 
 | Skill | Description |


### PR DESCRIPTION
## Summary
Added installation instructions to the README to help users get started with the JOYCO skills package.

## Changes
- Added a new "Install" section with a quick-start command using `pnpx` to add the skills package
- Placed the installation instructions prominently before the Skills section for better discoverability

## Details
The installation command `pnpx skills add joyco-studio/skills` provides users with a straightforward way to integrate these agent skills into their projects.

https://claude.ai/code/session_01AKWqJCY5oYkVuyPjKQN8aA