### PR TITLE
Add proactive GitHub PR detection and direct update capability

### DIFF
--- a/skills/pr-description-writer/SKILL.md
+++ b/skills/pr-description-writer/SKILL.md
@@ -5,10 +5,12 @@ description: >
   Supports issue, feature, and big-feature PR types with structured,
   production-ready output. Also generates PR titles and supports
   delivery as chat output or downloadable .md file.
+  Proactively detects open GitHub PRs for the current branch and offers
+  to update their title and description directly via the gh CLI.
 license: MIT
 metadata:
   author: joyco-studio
-  version: "0.0.1"
+  version: "0.0.2"
 ---
 
 # PR Description Writer Skill
@@ -16,6 +18,21 @@ metadata:
 This skill generates clean, structured, production-ready Pull Request descriptions in Markdown format.
 
 The user provides context about their PR (changes, bug, feature, architecture, etc). The skill determines or asks for the PR type and generates the correct template.
+
+---
+
+## Proactive PR Detection
+
+Before generating anything, **always** check if an open Pull Request already exists for the current branch using the `gh` CLI:
+
+```bash
+gh pr view --json number,title,url,body 2>/dev/null
+```
+
+- If a PR is found, note its number, current title, URL, and body. Inform the user that an open PR was detected and show the PR URL.
+- If no PR is found (command exits non-zero), skip this step and proceed normally.
+
+This detection is **automatic** — do not ask the user whether to check. Always check.
 
 ---
 
@@ -213,13 +230,48 @@ Use for:
 
 After generating the PR Title and PR Description, the skill must ask the user how they want to receive the output.
 
-Ask:
+**If an open PR was detected** for the current branch, present these options:
+
+"Do you want me to update the open PR directly, generate a `.md` file, or just show it here?"
+
+Options:
+- **Update the open PR** (recommended when a PR was detected) — uses `gh pr edit` to update title and body directly on GitHub.
+- Show in chat
+- Generate `.md` file
+
+**If no open PR was detected**, present the standard options:
 
 "Do you want me to generate a `.md` file with this content, or just show it here?"
 
 Options:
 - Show in chat (default)
 - Generate `.md` file
+
+---
+
+## Updating an Open PR
+
+When the user confirms they want to update the open PR, use the `gh` CLI:
+
+```bash
+gh pr edit <number> --title "<new title>" --body "<new body>"
+```
+
+Rules:
+- **Never update the PR without explicit user confirmation.** Always ask first using `AskUserQuestion`.
+- The `<number>` comes from the PR detected in the Proactive PR Detection step.
+- The `<new title>` is the generated PR title.
+- The `<new body>` is the generated PR description body (Markdown). Pass it via a heredoc to preserve formatting:
+
+```bash
+gh pr edit <number> --title "<new title>" --body "$(cat <<'EOF'
+<generated PR description body>
+EOF
+)"
+```
+
+- After a successful update, confirm to the user and show the PR URL.
+- If the update fails, show the error and fall back to displaying the output in chat so the user can copy/paste manually.
 
 ---
 
@@ -239,24 +291,28 @@ If the user requests a `.md` file:
 
 When running this skill:
 
-1. Detect PR type from context OR ask user to choose:
+1. **Proactively check for an open PR** on the current branch using `gh pr view`. This is automatic — do not ask the user whether to check. If a PR is found, inform the user (show PR URL and number).
+
+2. Detect PR type from context OR ask user to choose:
    - issue
    - feature
    - big-feature
 
-2. Always ask if there is a related issue link.
+3. Always ask if there is a related issue link.
 
-3. If issue exists, add Issue section at the top.
+4. If issue exists, add Issue section at the top.
 
-4. Generate:
+5. Generate:
    - PR Title
    - PR Description (Markdown body)
 
-5. Ask how to deliver the output:
-   - Show in chat
-   - Generate `.md` file
+6. Ask how to deliver the output:
+   - If an open PR was detected: offer to **update the PR directly**, show in chat, or generate `.md` file. Use `AskUserQuestion` to confirm.
+   - If no open PR: offer to show in chat or generate `.md` file.
 
-6. If `.md` file is requested, generate file-ready Markdown content.
+7. If the user chose to update the open PR, run `gh pr edit` with the generated title and body. **Never run this without confirmation.**
+
+8. If `.md` file is requested, generate file-ready Markdown content.
 
 ---
 


### PR DESCRIPTION
## Summary
Enhanced the PR Description Writer skill to automatically detect open pull requests on the current branch and offer to update them directly via the GitHub CLI, eliminating the need to manually copy-paste generated content.

## Key Changes
- **Proactive PR Detection**: Added automatic check for existing open PRs using `gh pr view` before generating any content. This detection runs without user prompting.
- **Direct PR Updates**: Implemented ability to update detected PRs directly using `gh pr edit` with generated title and body, with explicit user confirmation required.
- **Enhanced Output Options**: Modified the delivery prompt to offer three options when a PR is detected (update PR, show in chat, generate .md file) versus two options when no PR exists.
- **Improved Workflow**: Users can now update existing PRs in one step instead of manually editing on GitHub or copying generated content.
- **Version Bump**: Updated skill version from 0.0.1 to 0.0.2.

## Implementation Details
- PR detection uses `gh pr view --json number,title,url,body` with error handling for cases where no PR exists
- PR updates use `gh pr edit <number>` with heredoc syntax to preserve Markdown formatting in the body
- All PR updates require explicit user confirmation via `AskUserQuestion` before execution
- Fallback to chat display if `gh pr edit` fails, allowing manual copy-paste as alternative
- Updated execution flow documentation to reflect the new proactive detection step and conditional output options

https://claude.ai/code/session_011GX9mDKWM1biv42k192TwN