### PR TITLE
feat: add joyco-logs skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ pnpx skills add joyco-studio/skills
 | Skill | Description |
 |-------|-------------|
 | [joyco-app](skills/joyco-app/SKILL.md) | Carry a new JOYCO internal Next.js product app from plan to working build: lock a plan first, run the opinionated kickoff (JOYCO UI shadcn kit — theme, fonts, `@joyco/*` components from hub.joyco.studio — plus lint config and the Claude Code agent), then build it out to the plan. User-invocable as `/joyco-app`. |
+| [joyco-logs](skills/joyco-logs/SKILL.md) | Before implementing or planning a non-trivial feature, check the JOYCO dev-team logs (`hub.joyco.studio/logs`) for a relevant write-up and read it first. Surfaces the team's gotchas/patterns, defers to dedicated skills on overlap, and credits the source article to the user. |
 | [lab-experiment](skills/lab-experiment/SKILL.md) | Automates extracting self-contained experiments from any codebase, scaffolding with JOYCO templates, deploying to Vercel, and publishing to the JOYCO Lab registry. Handles 3D, animation, and interactive code experiments. |
 | [parallel-claudes](skills/parallel-claudes/SKILL.md) | Guide for running multiple parallel Claude Code sessions using `cw` (Claude Worktree Manager). Covers git worktree management, concurrent AI coding tasks, and merging results. |
 | [pr-description-writer](skills/pr-description-writer/SKILL.md) | Generate high-quality PR descriptions in Markdown. Supports issue, feature, and big-feature PR types with structured, production-ready output. |

--- a/skills/joyco-logs/SKILL.md
+++ b/skills/joyco-logs/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: joyco-logs
+description: >
+  Before implementing or planning a non-trivial feature or task, check the
+  JOYCO dev-team logs (hub.joyco.studio/logs) for an article that covers the
+  ground you're about to work on, and read it first. The logs are the team's
+  written knowledge — gotchas, patterns, and hard-won fixes (phantom merge
+  conflicts, layout thrashing, reduced-motion + GSAP, Next.js PPR/promises,
+  WebGL scroll sync, the slot approach, …). Trigger when starting real
+  implementation or planning work in a JOYCO repo — building a feature,
+  designing an approach, debugging a gnarly issue. Do NOT trigger on trivial
+  edits (typos, renames, one-line tweaks) or pure questions. When a log informs
+  the work, tell the user and link the specific article.
+license: MIT
+metadata:
+  author: joyco-studio
+  version: "0.0.1"
+---
+
+# JOYCO Logs — check the team's knowledge first
+
+The JOYCO dev team writes up gotchas, patterns, and hard-won fixes as **logs** at `https://hub.joyco.studio/logs`. Before you build or plan something non-trivial, scan that index — if a log covers the ground you're about to work on, reading it first can save you from a known trap or hand you the team's preferred approach.
+
+The point is to **surface prior art the dev may not know exists.** If the dev already knows a log is relevant, they'll paste the link. This skill is for the case where they don't.
+
+---
+
+## When to use
+
+Trigger **before starting real implementation or planning work** in a JOYCO repo:
+
+- Building a feature or a non-trivial component.
+- Designing/planning an approach before writing code.
+- Debugging a gnarly, non-obvious issue.
+
+Do **not** trigger on:
+
+- Trivial edits — typos, renames, one-line tweaks, formatting.
+- Pure questions that don't lead to implementation.
+- Cases where the dev already pointed you at a specific log (just read that one).
+
+The cost of this skill is one index scan; it only pays off when there's substantive new work where unknown prior art could bite. Don't run it on the long tail of tiny tasks.
+
+---
+
+## How to use it
+
+### 1. Fetch the index
+
+```bash
+curl -s https://hub.joyco.studio/logs.md
+```
+
+This returns a markdown list of every log — title and `/logs/NN-slug` link, reverse-chronological.
+
+> **If the index comes back as a placeholder** (e.g. an unrendered `<CategoryIndex .../>` tag instead of a list), the hub's raw-markdown index isn't serving the list yet. Fall back to fetching the rendered page with WebFetch (`https://hub.joyco.studio/logs`) and read the entry titles/links from there. (Tracking: the hub should make `/logs.md` emit a real markdown list — until then, the WebFetch fallback is correct.)
+
+### 2. Match against the task
+
+Read the titles. Is any log on-topic for what you're about to implement, plan, or debug? Match on the *problem domain*, not exact wording — "WTF Is Layout Thrashing" is relevant to "my scroll handler is janky"; "Promises, PPR, and the Root Provider Pattern" is relevant to "set up data fetching in the app router".
+
+- **No match** → say so in one short line and proceed. Don't force a connection or pad the work with an irrelevant log.
+- **Match** → continue.
+
+### 3. If a matched log has a dedicated skill, defer to the skill
+
+Some logs have a specialized skill that goes deeper than the article. When the topic matches one of these, **use the skill** rather than (or in addition to) the log — the skill is the richer, maintained source:
+
+| Log topic | Use this skill instead |
+|---|---|
+| Phantom / merge conflicts, rewritten history | `resolving-git-conflicts` |
+| Layout thrashing, forced reflow | `thrash-report-analyzer` |
+| Parallel Claude sessions / `cw` worktrees | `parallel-claudes` |
+
+(If a log topic gains a dedicated skill later, prefer the skill — this list isn't exhaustive.)
+
+### 4. Read the log and apply it
+
+For a matched log with no dedicated skill, fetch the article markdown and read it before writing code:
+
+```bash
+curl -s https://hub.joyco.studio/logs/NN-slug.md
+```
+
+Let it inform the approach — follow the team's pattern, avoid the documented trap.
+
+### 5. Attribute the source to the user
+
+When a log (or a log-backed skill) actually shaped the fix or approach, **tell the user where it came from and link the specific article.** This credits the team's written knowledge and lets the dev open the full write-up. For example:
+
+> Heads up — I applied the approach from the JOYCO log **[Promises, PPR, and the Root Provider Pattern](https://hub.joyco.studio/logs/07-nextjs-promises-ppr)**: wrapping the data promise in the root provider instead of awaiting it per-route.
+
+Always link the exact `/logs/NN-slug` URL, not just `/logs`. If you deferred to a dedicated skill, name both the skill and the originating log if you scanned it.
+
+---
+
+## Pitfalls
+
+- **Forcing a match.** Most tasks won't have a relevant log. "Nothing relevant in the logs" is a fine, expected outcome — say it in one line and move on. Don't shoehorn an unrelated article in to look thorough.
+- **Reading the log but not crediting it.** If a log changed what you did, the dev should know — link it (step 5).
+- **Linking the index instead of the article.** Always give the specific `/logs/NN-slug` URL.
+- **Re-deriving what a dedicated skill already owns.** If the topic maps to `resolving-git-conflicts` / `thrash-report-analyzer` / `parallel-claudes`, use that skill.
+- **Triggering on trivial work.** A rename doesn't need a logs scan. Respect the "when to use" gate or the skill becomes noise.
+
+---
+
+## Checklist
+
+- [ ] Scanned the logs index before starting non-trivial implementation/planning (not on a trivial edit).
+- [ ] Matched on problem domain; if nothing fit, said so in one line and proceeded.
+- [ ] For a matched topic with a dedicated skill, deferred to that skill.
+- [ ] Read the relevant log's markdown before writing the code it informs.
+- [ ] Told the user the knowledge came from the logs and linked the specific `/logs/NN-slug` article.


### PR DESCRIPTION
## What

Adds `joyco-logs` — a skill that checks the JOYCO dev-team logs at `hub.joyco.studio/logs` for relevant prior art **before** non-trivial implementation or planning, and reads the matching write-up first.

## Why

The team drops hard-won knowledge into the logs (phantom merge conflicts, layout thrashing, reduced-motion + GSAP, Next.js PPR/promises, WebGL scroll sync, the slot approach, …). The value is catching the case where a dev is about to build something a log already covers **and doesn't know the log exists** — if they knew, they'd just paste the link.

## Design decisions (from team discussion)

- **Skill, not a hook.** A hook fires deterministically and can't reason about relevance — it'd inject "check the logs" on every prompt, including trivial ones. A skill's description is the relevance filter: it only triggers on substantive work. (This was the explicit ask — an auto-triggering skill that stays quiet otherwise, not a blunt hook.)
- **Scoped to feature/plan/debug work, silent on trivial edits.** Triggering costs an index scan; it only pays off where unknown prior art could bite. Renames/typos/one-liners don't trigger it. (Chosen over broad "any dev task" triggering to keep it from becoming noise the team learns to ignore.)
- **Defers to dedicated skills on overlap.** Several logs already have richer skills — Phantom Merge Conflicts → `resolving-git-conflicts`, Layout Thrashing → `thrash-report-analyzer`, Parallel Claudes → `parallel-claudes`. On those topics the skill points at the skill, not just the article, so two sources can't drift apart.
- **Credits the source to the user.** When a log shapes the fix/approach, the skill tells the user and links the specific `/logs/NN-slug` article — auditable, and lets the dev open the full write-up.

## ⚠️ Depends on a hub change

`https://hub.joyco.studio/logs.md` currently returns an unrendered `<CategoryIndex category=\"logs\" />` placeholder, not a markdown list — so the index isn't machine-scannable yet. The skill targets the fixed `.md` index and includes a documented **WebFetch fallback** (the rendered HTML page does list the entries), so it works today and gets cleaner once the hub serves a real list. A separate prompt to fix the hub index has been handed to the team.

## Notes

- Separate PR from #10 (the `joyco-ui` thin-router refactor) — different concern.
- The README's `joyco-ui` row still shows its pre-refactor description here; that's corrected in #10, not touched on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds the `joyco-logs` skill, which instructs Claude to scan the JOYCO dev-team logs at `hub.joyco.studio/logs` for relevant prior art before starting any non-trivial implementation or planning work in a JOYCO repo.

- **`skills/joyco-logs/SKILL.md`**: New skill with clearly scoped trigger conditions, a documented WebFetch fallback for the currently-broken `.md` index endpoint, a cross-reference table mapping log topics to three existing dedicated skills (`resolving-git-conflicts`, `thrash-report-analyzer`, `parallel-claudes`), and a checklist. All three referenced skills are confirmed present in the repo.
- **`README.md`**: Adds the `joyco-logs` row in the correct alphabetical position between `joyco-app` and `lab-experiment`.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive documentation (a new skill file and a README row) with no runtime code.

Both files are documentation only. The skill's cross-referenced skills all exist in the repo, the known broken index endpoint has an explicit fallback documented, and the README row lands in the correct alphabetical position. Nothing in the diff can cause a regression.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| skills/joyco-logs/SKILL.md | New skill file adding joyco-logs — well-structured frontmatter, clear trigger conditions, fallback documented for the known broken index endpoint, all three cross-referenced skills (resolving-git-conflicts, thrash-report-analyzer, parallel-claudes) confirmed to exist in the repo. |
| README.md | Adds joyco-logs row in the correct alphabetical position (between joyco-app and lab-experiment); description matches the skill frontmatter. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `README.md`, line 26-27 ([link](https://github.com/joyco-studio/skills/blob/b23337da0889872fef3f5ccc7296f0b4488270a6/README.md#L26-L27)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `joyco-ui` row was appended at the bottom of the table, but `joyco-app` and `joyco-logs` are grouped at the top — splitting the three `joyco-*` skills across opposite ends of the list. Moving the row here and inserting it after `joyco-logs` would keep that cluster together.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: README.md
   Line: 26-27

   Comment:
   The `joyco-ui` row was appended at the bottom of the table, but `joyco-app` and `joyco-logs` are grouped at the top — splitting the three `joyco-*` skills across opposite ends of the list. Moving the row here and inserting it after `joyco-logs` would keep that cluster together.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

2. `skills/joyco-ui/components.md`, line 345-349 ([link](https://github.com/joyco-studio/skills/blob/b23337da0889872fef3f5ccc7296f0b4488270a6/skills/joyco-ui/components.md#L345-L349)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The inner `<div className="bg-muted rounded-md p-4 text-sm">` matches the antipattern explicitly warned against in `SKILL.md` — "Don't wrap content in a `<div>` with `bg-*` + `p-*` to fake a card; use `<Cluster>`." Since this is the reference document developers copy from, showing the forbidden pattern here could undermine the guidance.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: skills/joyco-ui/components.md
   Line: 345-349

   Comment:
   The inner `<div className="bg-muted rounded-md p-4 text-sm">` matches the antipattern explicitly warned against in `SKILL.md` — "Don't wrap content in a `<div>` with `bg-*` + `p-*` to fake a card; use `<Cluster>`." Since this is the reference document developers copy from, showing the forbidden pattern here could undermine the guidance.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["feat: add joyco-logs skill"](https://github.com/joyco-studio/skills/commit/b23337da0889872fef3f5ccc7296f0b4488270a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38138258)</sub>

<!-- /greptile_comment -->